### PR TITLE
Keep build time consistent for spec and dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Update mentions of the default branch from 'master' to 'main'. [#54](https://github.com/xmidt-org/petasos/pull/54)
+- Update buildtime format in Makefile to match RPM spec file. [#61](https://github.com/xmidt-org/petasos/pull/61)
 
 ## [v0.1.5]
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DOCKER_ORG   := xmidt
 
 VERSION ?= $(shell git describe --tag --always --dirty)
 PROGVER ?= $(shell git describe --tags `git rev-list --tags --max-count=1` | tail -1 | sed 's/v\(.*\)/\1/')
-BUILDTIME = $(shell date -u '+%Y-%m-%d %H:%M:%S')
+BUILDTIME = $(shell date -u '+%c')
 GITCOMMIT = $(shell git rev-parse --short HEAD)
 GOBUILDFLAGS = -a -ldflags "-w -s -X 'main.BuildTime=$(BUILDTIME)' -X main.GitCommit=$(GITCOMMIT) -X main.Version=$(VERSION)" -o $(APP)
 


### PR DESCRIPTION
Part of https://github.com/xmidt-org/xmidt/issues/37