### PR TITLE
release petasos with docker arm images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ on:
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@a98d20363e6225b37af9aa8d2b3c4bdfedbe8020 # v4.8.7
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@39e0c06dc85a40778331da295d9cb3b70a9e2bb8 # v4.8.9
     with:
       release-type:          program
-      release-arch-arm64:    true
       release-arch-amd64:    true
+      release-arch-arm64:    true
       release-docker:        true
       release-docker-latest: true
       release-docker-major:  true


### PR DESCRIPTION
in theory, this should have already released arm.  I just updated to a later shared-go version and will try again push another release to see what happens. 